### PR TITLE
fix(content) Add security guidelines

### DIFF
--- a/_plays/03.md
+++ b/_plays/03.md
@@ -5,6 +5,17 @@ title: Ce ar trebui să conțină un issue?
 
 Exceptând issues sub formă de întrebare (Cum se numește canalul de Slack al proiectului? etc.), fiecare issue ar trebui să conțină câteva elemente ce permit membrilor unui proiect să acționeze cât mai rapid:
 
+### Pentru raportarea problemelor de securitate
+- Orice problemă de securitate trebuie raportată pe [security@civictech.ro](mailto:security@civictech.ro)
+- În cazul în care dorești să raportezi o problemă de securitate pe un alt canal, poți aborda [unul dintre membrii core-team](https://civictech.ro/cine-suntem) pe Slack, în privat. 
+- Te rugăm să faci tot posibilul să eviți privacy violations, distrugere de date, întreruperi sau degradări ale serviciilor. Nu interacționa decât cu conturi care îți aparțin sau doar atunci când ai permisiunea expresă a owner-ului.
+- Nu încerca atacuri care ar putea afecta integritatea serviciilor oferite. Atacurile de tip DDOS/spam nu sunt permise.
+- Nu încerca atacuri non-tehnice precum social-engineering, phishing, sau atacuri fizice asupra membrilor permanenți CivicTech România, membrilor comunității sau asupra infrastructurii CivicTech România.
+- Ca și regulă pentru noi, vom încerca să fim cât mai responsive și să patch-uim problema cât mai repede, astfel încât să putem să îți mulțumim public și să anunțăm corecția vulnerabilității.
+- Ca și regulă pentru tine, te rugăm să ai răbdare până la patch-uirea problemei, astfel încât utilizatorii să nu fie afectați. De asemnea te rugăm să incluzi atât pașii necesari pentru reproducere cât și clarificări în ceea ce privește metoda de exploatare posibilă. 
+- Cât timp jucăm cu toții după reguli, nu vom lua acțiune legală asupra ta. 
+- *Standardul de responsible disclosure folosit în industrie este [ISO/IEC 29147:2014](http://standards.iso.org/ittf/PubliclyAvailableStandards/c045170_ISO_IEC_29147_2014.zip), disponibil gratuit după acceptarea licenței. Avem în lucru adoptarea unei platforme de responsible disclosure, dacă dorești să fii la curent cu noutățile te așteptăm pe [canalul de Slack #security](https://civictechro.slack.com/messages/CAFSW6HU4).*
+
 ### Pentru raportarea bug-urilor
 -  Ce te așteptai să se întâmple?
 -  Ce s-a întâmplat de fapt?

--- a/_plays/03.md
+++ b/_plays/03.md
@@ -11,10 +11,10 @@ Exceptând issues sub formă de întrebare (Cum se numește canalul de Slack al 
 - Te rugăm să faci tot posibilul să eviți privacy violations, distrugere de date, întreruperi sau degradări ale serviciilor. Nu interacționa decât cu conturi care îți aparțin sau doar atunci când ai permisiunea expresă a owner-ului.
 - Nu încerca atacuri care ar putea afecta integritatea serviciilor oferite. Atacurile de tip DDOS/spam nu sunt permise.
 - Nu încerca atacuri non-tehnice precum social-engineering, phishing, sau atacuri fizice asupra membrilor permanenți CivicTech România, membrilor comunității sau asupra infrastructurii CivicTech România.
-- Ca și regulă pentru noi, vom încerca să fim cât mai responsive și să patch-uim problema cât mai repede, astfel încât să putem să îți mulțumim public și să anunțăm corecția vulnerabilității.
-- Ca și regulă pentru tine, te rugăm să ai răbdare până la patch-uirea problemei, astfel încât utilizatorii să nu fie afectați. De asemnea te rugăm să incluzi atât pașii necesari pentru reproducere cât și clarificări în ceea ce privește metoda de exploatare posibilă. 
-- Cât timp jucăm cu toții după reguli, nu vom lua acțiune legală asupra ta. 
-- *Standardul de responsible disclosure folosit în industrie este [ISO/IEC 29147:2014](http://standards.iso.org/ittf/PubliclyAvailableStandards/c045170_ISO_IEC_29147_2014.zip), disponibil gratuit după acceptarea licenței. Avem în lucru adoptarea unei platforme de responsible disclosure, dacă dorești să fii la curent cu noutățile te așteptăm pe [canalul de Slack #security](https://civictechro.slack.com/messages/CAFSW6HU4).*
+- Ca regulă pentru noi, vom încerca să fim cât mai responsive și să patch-uim problema cât mai repede, astfel încât să putem să îți mulțumim public și să anunțăm corecția vulnerabilității.
+- Ca regulă pentru tine, te rugăm să ai răbdare până la patch-uirea problemei, astfel încât utilizatorii să nu fie afectați. De asemenea te rugăm să incluzi atât pașii necesari pentru reproducere, cât și clarificări în ceea ce privește metoda de exploatare posibilă. 
+- Cât timp jucăm cu toții după reguli, nu vom începe o acțiune legală asupra ta. 
+- *Standardul de responsible disclosure folosit în industrie este [ISO/IEC 29147:2014](http://standards.iso.org/ittf/PubliclyAvailableStandards/c045170_ISO_IEC_29147_2014.zip), disponibil gratuit după acceptarea licenței. Avem în lucru adoptarea unei platforme de responsible disclosure, dacă dorești să fii la curent cu noutățile, te așteptăm pe [canalul de Slack #security](https://civictechro.slack.com/messages/CAFSW6HU4).*
 
 ### Pentru raportarea bug-urilor
 -  Ce te așteptai să se întâmple?

--- a/_plays/03.md
+++ b/_plays/03.md
@@ -9,7 +9,7 @@ Exceptând issues sub formă de întrebare (Cum se numește canalul de Slack al 
 - Orice problemă de securitate trebuie raportată pe [security@civictech.ro](mailto:security@civictech.ro)
 - În cazul în care dorești să raportezi o problemă de securitate pe un alt canal, poți aborda [unul dintre membrii core-team](https://civictech.ro/cine-suntem) pe Slack, în privat. 
 - Te rugăm să faci tot posibilul să eviți privacy violations, distrugere de date, întreruperi sau degradări ale serviciilor. Nu interacționa decât cu conturi care îți aparțin sau doar atunci când ai permisiunea expresă a owner-ului.
-- Nu încerca atacuri care ar putea afecta integritatea serviciilor oferite. Atacurile de tip DDOS/spam nu sunt permise.
+- Nu încerca atacuri care ar putea afecta integritatea serviciilor oferite. Atacurile de tip DDoS/spam nu sunt permise.
 - Nu încerca atacuri non-tehnice precum social-engineering, phishing, sau atacuri fizice asupra membrilor permanenți CivicTech România, membrilor comunității sau asupra infrastructurii CivicTech România.
 - Ca regulă pentru noi, vom încerca să fim cât mai responsive și să patch-uim problema cât mai repede, astfel încât să putem să îți mulțumim public și să anunțăm corecția vulnerabilității.
 - Ca regulă pentru tine, te rugăm să ai răbdare până la patch-uirea problemei, astfel încât utilizatorii să nu fie afectați. De asemenea te rugăm să incluzi atât pașii necesari pentru reproducere, cât și clarificări în ceea ce privește metoda de exploatare posibilă. 


### PR DESCRIPTION
Până când ni se aprobă înscrierea pe HackerOne, cred că e util să avem un scurt ghid și aici (plus anunțarea adresei de email)